### PR TITLE
Add scheduled task for message creation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,11 @@ dependencies {
     implementation("org.mapstruct:mapstruct:1.5.5.Final")
     // https://mvnrepository.com/artifact/com.hazelcast/hazelcast-spring
     implementation("com.hazelcast:hazelcast-spring:5.4.0")
+    // https://mvnrepository.com/artifact/net.javacrumbs.shedlock/shedlock-spring
+    implementation("net.javacrumbs.shedlock:shedlock-spring:5.13.0")
+    // https://mvnrepository.com/artifact/net.javacrumbs.shedlock/shedlock-provider-hazelcast
+    implementation("net.javacrumbs.shedlock:shedlock-provider-hazelcast4:5.13.0")
+
     compileOnly("org.projectlombok:lombok")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("org.postgresql:postgresql")

--- a/src/main/java/com/tfl/haltrial/config/HazelcastConfiguration.java
+++ b/src/main/java/com/tfl/haltrial/config/HazelcastConfiguration.java
@@ -4,6 +4,7 @@ import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.core.HazelcastInstance;
+import net.javacrumbs.shedlock.provider.hazelcast4.HazelcastLockProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -20,5 +21,10 @@ public class HazelcastConfiguration {
     @Primary
     public HazelcastInstance hazelcastInstance(ClientConfig clientConfig) {
         return HazelcastClient.newHazelcastClient(clientConfig);
+    }
+
+    @Bean
+    public HazelcastLockProvider lockProvider(HazelcastInstance hazelcastInstance) {
+        return new HazelcastLockProvider(hazelcastInstance);
     }
 }

--- a/src/main/java/com/tfl/haltrial/config/ScheduleTasksConfiguration.java
+++ b/src/main/java/com/tfl/haltrial/config/ScheduleTasksConfiguration.java
@@ -1,0 +1,48 @@
+package com.tfl.haltrial.config;
+
+import com.tfl.haltrial.domain.dto.MessageDto;
+import com.tfl.haltrial.messaging.HazelcastConsumer;
+import com.tfl.haltrial.messaging.dto.SendMessageEvent;
+import com.tfl.haltrial.services.MessageService;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.core.LockAssert;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.List;
+
+@Slf4j
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "10s")
+@Configuration
+public class ScheduleTasksConfiguration {
+
+    private final HazelcastConsumer consumer;
+    private final MessageService messageService;
+
+    public ScheduleTasksConfiguration(HazelcastConsumer consumer, MessageService messageService) {
+        this.consumer = consumer;
+        this.messageService = messageService;
+    }
+
+    @SchedulerLock(name = "createMessagesTask")
+    @Scheduled(fixedRate = 5000)
+    public void createMessages() {
+        LockAssert.assertLocked();
+        List<SendMessageEvent> events = consumer.consumeMessages();
+        if (events.isEmpty()) {
+            log.info("No events in queue");
+            return;
+        }
+        List<MessageDto> messageDtos = messageService.createMessagesFromEvents(events);
+        if (events.size() != messageDtos.size()) {
+            log.warn("Some messages were not created for {} events. Created messages size {}", events.size(),
+                    messageDtos.size());
+            return;
+        }
+        log.info("Created {} messages", messageDtos.size());
+    }
+}

--- a/src/main/java/com/tfl/haltrial/messaging/HazelcastConsumer.java
+++ b/src/main/java/com/tfl/haltrial/messaging/HazelcastConsumer.java
@@ -1,0 +1,33 @@
+package com.tfl.haltrial.messaging;
+
+import com.hazelcast.collection.IQueue;
+import com.hazelcast.core.HazelcastInstance;
+import com.tfl.haltrial.config.MessagingProperties;
+import com.tfl.haltrial.messaging.dto.SendMessageEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class HazelcastConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(HazelcastConsumer.class);
+    private final HazelcastInstance hazelcastInstance;
+    private final String queueName;
+
+    public HazelcastConsumer(HazelcastInstance hazelcastInstance, MessagingProperties properties) {
+        this.hazelcastInstance = hazelcastInstance;
+        this.queueName = properties.getQueueName();
+    }
+
+    public List<SendMessageEvent> consumeMessages() {
+        IQueue<SendMessageEvent> messageQueue = hazelcastInstance.getQueue(queueName);
+        List<SendMessageEvent> eventList = new ArrayList<>();
+        int result = messageQueue.drainTo(eventList);
+        log.info("Consumed {} messages", result);
+        return eventList;
+    }
+}

--- a/src/main/java/com/tfl/haltrial/repositories/ClientRepository.java
+++ b/src/main/java/com/tfl/haltrial/repositories/ClientRepository.java
@@ -3,8 +3,12 @@ package com.tfl.haltrial.repositories;
 import com.tfl.haltrial.domain.entity.ClientEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
+
 public interface ClientRepository extends JpaRepository<ClientEntity, Long> {
 
     boolean existsByLogin(String login);
 
+    List<ClientEntity> findAllByLoginIn(Collection<String> logins);
 }

--- a/src/main/java/com/tfl/haltrial/repositories/MessageRepository.java
+++ b/src/main/java/com/tfl/haltrial/repositories/MessageRepository.java
@@ -1,0 +1,7 @@
+package com.tfl.haltrial.repositories;
+
+import com.tfl.haltrial.domain.entity.MessageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageRepository extends JpaRepository<MessageEntity, Long> {
+}

--- a/src/main/java/com/tfl/haltrial/services/ClientService.java
+++ b/src/main/java/com/tfl/haltrial/services/ClientService.java
@@ -1,13 +1,18 @@
 package com.tfl.haltrial.services;
 
 import com.tfl.haltrial.domain.dto.ClientDto;
+import com.tfl.haltrial.domain.entity.ClientEntity;
 
 import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
 
 public interface ClientService {
 
     ClientDto createClient(String login, String firstName, String lastName, String patronymic, LocalDate birthday);
 
     boolean clientExists(String login);
+
+    List<ClientEntity> getClientsByLogins(Collection<String> logins);
 
 }

--- a/src/main/java/com/tfl/haltrial/services/ClientServiceImpl.java
+++ b/src/main/java/com/tfl/haltrial/services/ClientServiceImpl.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
 
 @Service
 public class ClientServiceImpl implements ClientService {
@@ -43,5 +45,11 @@ public class ClientServiceImpl implements ClientService {
     @Override
     public boolean clientExists(String login) {
         return clientRepository.existsByLogin(login);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<ClientEntity> getClientsByLogins(Collection<String> logins) {
+        return clientRepository.findAllByLoginIn(logins);
     }
 }

--- a/src/main/java/com/tfl/haltrial/services/MessageService.java
+++ b/src/main/java/com/tfl/haltrial/services/MessageService.java
@@ -1,8 +1,14 @@
 package com.tfl.haltrial.services;
 
+import com.tfl.haltrial.domain.dto.MessageDto;
+import com.tfl.haltrial.messaging.dto.SendMessageEvent;
+
+import java.util.List;
 import java.util.UUID;
 
 public interface MessageService {
 
     UUID sendMessage(String toClient, String body);
+
+    List<MessageDto> createMessagesFromEvents(List<SendMessageEvent> events);
 }

--- a/src/main/java/com/tfl/haltrial/services/MessageServiceImpl.java
+++ b/src/main/java/com/tfl/haltrial/services/MessageServiceImpl.java
@@ -1,22 +1,38 @@
 package com.tfl.haltrial.services;
 
+import com.tfl.haltrial.domain.dto.MessageDto;
+import com.tfl.haltrial.domain.entity.ClientEntity;
+import com.tfl.haltrial.domain.entity.MessageEntity;
+import com.tfl.haltrial.domain.mapper.MessageMapper;
 import com.tfl.haltrial.messaging.HazelcastProducer;
+import com.tfl.haltrial.messaging.dto.SendMessageEvent;
 import com.tfl.haltrial.messaging.exceptions.QueueFullException;
+import com.tfl.haltrial.repositories.MessageRepository;
 import com.tfl.haltrial.services.exceptions.CannotSendMessageException;
 import com.tfl.haltrial.services.exceptions.ObjectNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 public class MessageServiceImpl implements MessageService {
 
     private final ClientService clientService;
     private final HazelcastProducer producer;
+    private final MessageRepository messageRepository;
+    private final MessageMapper messageMapper;
 
-    public MessageServiceImpl(ClientService clientService, HazelcastProducer producer) {
+    public MessageServiceImpl(ClientService clientService, HazelcastProducer producer,
+                              MessageRepository messageRepository, MessageMapper messageMapper) {
         this.clientService = clientService;
         this.producer = producer;
+        this.messageRepository = messageRepository;
+        this.messageMapper = messageMapper;
     }
 
 
@@ -30,5 +46,24 @@ public class MessageServiceImpl implements MessageService {
         } catch (QueueFullException queueFullException) {
             throw new CannotSendMessageException("Cannot send message", queueFullException);
         }
+    }
+
+    @Transactional
+    @Override
+    public List<MessageDto> createMessagesFromEvents(List<SendMessageEvent> events) {
+        List<String> logins = events.stream().map(SendMessageEvent::toLogin).toList();
+        Map<String, ClientEntity> clientEntities = clientService.getClientsByLogins(logins)
+                .stream()
+                .collect(Collectors.toMap(ClientEntity::getLogin, Function.identity()));
+        List<MessageEntity> entities = events.stream()
+                .filter(e -> clientEntities.containsKey(e.toLogin()))
+                .map(e -> {
+                    ClientEntity client = clientEntities.get(e.toLogin());
+                    return MessageEntity.builder()
+                            .client(client)
+                            .body(e.body())
+                            .build();
+                }).toList();
+        return messageRepository.saveAll(entities).stream().map(messageMapper::entityToDto).toList();
     }
 }


### PR DESCRIPTION
Implemented a scheduled task that consumes events from a Hazelcast queue and creates messages from these events. Additionally, added Hazelcast lock provider configuration, extended ClientService to fetch clients by logins, and expanded MessageService to support creation of messages from events. Necessary dependencies were also added to the build file.